### PR TITLE
fix folder path not exist bug

### DIFF
--- a/notebooks/1 - Preprocess Data.ipynb
+++ b/notebooks/1 - Preprocess Data.ipynb
@@ -17,7 +17,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%load_ext autoreload\n",
@@ -161,7 +163,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def tokenize_docstring(text):\n",
@@ -471,7 +475,9 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def listlen(x):\n",
@@ -497,7 +503,9 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "grouped = with_docstrings.groupby('nwo')"
@@ -526,7 +534,9 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "train = pd.concat([d for _, d in train]).reset_index(drop=True)\n",
@@ -719,7 +729,9 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def write_to(df, filename, path='./data/processed_data/'):\n",
@@ -736,9 +748,14 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
+    "import os\n",
+    "if not os.path.exists('data/'):\n",
+    "    os.makedirs('data/')\n",
     "# write to output files\n",
     "write_to(train, 'train')\n",
     "write_to(valid, 'valid')\n",


### PR DESCRIPTION
In code `def write_to(df, filename, path='./data/processed_data/'):`

`data` folder should create first.